### PR TITLE
Zxkiller patch 1

### DIFF
--- a/src/Provider/Exception/IdentityProviderException.php
+++ b/src/Provider/Exception/IdentityProviderException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This exception is adapt for IdentityProviderException in league/oauth2-client library
+ */
+namespace zhangxiao\OAuth2\Client\Provider\Exception;
+
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException as OriginIdentityProviderException;
+
+/**
+ * Exception thrown if the provider response contains errors.
+ */
+class IdentityProviderException extends OriginIdentityProviderException
+{}

--- a/src/Provider/WebProvider.php
+++ b/src/Provider/WebProvider.php
@@ -3,10 +3,9 @@ namespace zhangxiao\OAuth2\Client\Provider;
 
 use GuzzleHttp\Psr7\Uri;
 use League\OAuth2\Client\Provider\AbstractProvider;
-use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
-//use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use Psr\Http\Message\ResponseInterface;
+use zhangxiao\OAuth2\Client\Provider\Exception\IdentityProviderException;
 
 class WebProvider extends AbstractProvider
 {


### PR DESCRIPTION
创建兼容异常类，可直接调用getResponseBody获取oauth server的response。
其他应用调用时也可避免跟踪该模块所依赖类库的异常类。